### PR TITLE
Added fallback for trimLeft using String.prototype

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,13 +89,8 @@ function parseSelector(subselects, selector, options){
         sawWS = false,
         data, firstChar, name, quot;
 
-    if (!String.prototype.trimLeft) {
-        String.prototype.trimLeft = function(){
-            return this.replace(/^\s+/, "");
-        }
-    }
-
-    selector = selector.trimLeft();
+    var trim = String.prototype.trimLeft || String.prototype.trim;
+    selector = trim.call(selector);
 
 	function getName(){
 		var sub = selector.match(re_name)[0];
@@ -119,14 +114,14 @@ function parseSelector(subselects, selector, options){
 			tokens.push({type: "tag", name: name});
 		} else if(re_ws.test(selector)){
 			sawWS = true;
-			selector = selector.trimLeft();
+			selector = trim.call(selector);
 		} else {
 			firstChar = selector.charAt(0);
 			selector = selector.substr(1);
 
 			if(firstChar in simpleSelectors){
 				tokens.push({type: simpleSelectors[firstChar]});
-				selector = selector.trimLeft();
+				selector = trim.call(selector);
 				sawWS = false;
 				continue;
 			} else if(firstChar === ","){
@@ -136,7 +131,7 @@ function parseSelector(subselects, selector, options){
 				subselects.push(tokens);
 				tokens = [];
 
-				selector = selector.trimLeft();
+				selector = trim.call(selector);
 				sawWS = false;
 				continue;
 			} else if(sawWS){

--- a/index.js
+++ b/index.js
@@ -89,6 +89,12 @@ function parseSelector(subselects, selector, options){
         sawWS = false,
         data, firstChar, name, quot;
 
+    if (!String.prototype.trimLeft) {
+        String.prototype.trimLeft = function(){
+            return this.replace(/^\s+/, "");
+        }
+    }
+
     selector = selector.trimLeft();
 
 	function getName(){


### PR DESCRIPTION
`trimLeft()` is non-standard and implementation might diff between browsers. Was causing errors in IE, for example. 