### PR TITLE
The :icontains selector also needs to be stripped of quotes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,8 @@ var unpackPseudos = {
 
 var stripQuotesFromPseudos = {
 	__proto__: null,
-	"contains": true
+	"contains": true,
+	"icontains": true
 };
 
 var quotes = {

--- a/tests/test.js
+++ b/tests/test.js
@@ -353,6 +353,32 @@ var tests = [
 		],
 		"pseudo selector with data"
 	],
+	[
+		":icontains('')",
+		[
+			[
+				{
+					"type": "pseudo",
+					"name": "icontains",
+					"data": ""
+				}
+			]
+		],
+		"pseudo selector with quote-stripped data"
+	],
+	[
+		":contains(\"(foo)\")",
+		[
+			[
+				{
+					"type": "pseudo",
+					"name": "contains",
+					"data": "(foo)"
+				}
+			]
+		],
+		"pseudo selector with data"
+	],
 
 	//multiple selectors
 	[


### PR DESCRIPTION
This is needed for `:icontains` support in [css-select](https://github.com/fb55/css-select/issues/33). Otherwise `:icontains('')` behaves differently from `:contains('')`.