### PR TITLE
Quoted attributes regex fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = parse;
 var re_name = /^(?:\\.|[\w\-\u00c0-\uFFFF])+/,
     re_escape = /\\([\da-f]{1,6}\s?|(\s)|.)/ig,
     //modified version of https://github.com/jquery/sizzle/blob/master/src/sizzle.js#L87
-    re_attr = /^\s*((?:\\.|[\w\u00c0-\uFFFF\-])+)\s*(?:(\S?)=\s*(?:(['"])(.*?)\3|(#?(?:\\.|[\w\u00c0-\uFFFF\-])*)|)|)\s*(i)?\]/;
+    re_attr = /^\s*((?:\\.|[\w\u00c0-\uFFFF\-])+)\s*(?:(\S?)=\s*(?:(['"])([\w\W]*?)\3|(#?(?:\\.|[\w\u00c0-\uFFFF\-])*)|)|)\s*(i)?\]/;
 
 var actionTypes = {
 	__proto__: null,

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = parse;
 var re_name = /^(?:\\.|[\w\-\u00c0-\uFFFF])+/,
     re_escape = /\\([\da-f]{1,6}\s?|(\s)|.)/ig,
     //modified version of https://github.com/jquery/sizzle/blob/master/src/sizzle.js#L87
-    re_attr = /^\s*((?:\\.|[\w\u00c0-\uFFFF\-])+)\s*(?:(\S?)=\s*(?:(['"])([\w\W]*?)\3|(#?(?:\\.|[\w\u00c0-\uFFFF\-])*)|)|)\s*(i)?\]/;
+    re_attr = /^\s*((?:\\.|[\w\u00c0-\uFFFF\-])+)\s*(?:(\S?)=\s*(?:(['"])([^]*?)\3|(#?(?:\\.|[\w\u00c0-\uFFFF\-])*)|)|)\s*(i)?\]/;
 
 var actionTypes = {
 	__proto__: null,

--- a/tests/test.js
+++ b/tests/test.js
@@ -251,6 +251,21 @@ var tests = [
 		"quoted attribute with spaces"
 	],
 	[
+		"[value=\"\nsome text\n\"]",
+		[
+			[
+				{
+					"type": "attribute",
+					"name": "value",
+					"action": "equals",
+					"value": "\nsome text\n",
+					"ignoreCase": false
+				}
+			]
+		],
+		"quoted attribute with internal newline"
+	],
+	[
 		"[name=foo\\.baz]",
 		[
 			[


### PR DESCRIPTION
Allows newlines `\n` to be inside quoted attribute values e.g. `[value="\nsomething"]`. Test included.
