### PR TITLE
Allow escaped parentheses in pseudo selectors

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,6 +104,13 @@ function parseSelector(subselects, selector, options){
 		selector = selector.substr(start);
 	}
 
+	function isEscaped(pos) {
+		var slashCount = 0;
+
+		while (selector.charAt(--pos) === "\\") slashCount++;
+		return (slashCount & 1) === 1;
+	}
+
 	stripWhitespace(0);
 
 	while(selector !== ""){
@@ -211,8 +218,8 @@ function parseSelector(subselects, selector, options){
 						var pos = 1, counter = 1;
 
 						for(; counter > 0 && pos < selector.length; pos++){
-							if(selector.charAt(pos) === "(") counter++;
-							else if(selector.charAt(pos) === ")") counter--;
+							if(selector.charAt(pos) === "(" && !isEscaped(pos)) counter++;
+							else if(selector.charAt(pos) === ")" && !isEscaped(pos)) counter--;
 						}
 
 						if(counter){


### PR DESCRIPTION
allows for the inclusion of escaped parenthesis inside of a sudo selector. Updated previous change to iterate backwards to also allow for the inclusion of escaped escape characters.