### PR TITLE
Use a specific SPDX identifier for the license

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "engines": {
     "node": "*"
   },
-  "license": "BSD-like",
+  "license": "BSD-2-Clause",
   "jshintConfig": {
     "eqeqeq": true,
     "freeze": true,


### PR DESCRIPTION
The `BSD-Like` isn't a valid [SPDX](https://spdx.org/licenses/) identifier and thus complicates auditing licenses and complying with them for anyone who uses `css-select` or any project depending on it.