### PR TITLE
Export the parse Options type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export { default as parse, Selector } from "./parse";
+export { default as parse, Selector, Options } from "./parse";
 export { default as stringify } from "./stringify";

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -2,7 +2,7 @@
 
 export default parse;
 
-interface Options {
+export interface Options {
     lowerCaseAttributeNames?: boolean;
     lowerCaseTags?: boolean;
     xmlMode?: boolean;


### PR DESCRIPTION
The parse options are part of the public API. Expose them so consumers and wrappers of the library can provide customization hooks without copying and pasting.