### PR TITLE
fix: Escape sequence in id selectors being ignored

### DIFF
--- a/src/__fixtures__/tests.ts
+++ b/src/__fixtures__/tests.ts
@@ -200,6 +200,21 @@ export const tests: [string, Selector[][], string][] = [
         ],
         "Numeric escape (outside BMP)"
     ],
+    [
+        "#\\26 B",
+        [
+            [
+                {
+                    type: "attribute",
+                    action: "equals",
+                    name: "id",
+                    value: "&B",
+                    ignoreCase: false
+                },
+            ]
+        ],
+        "id selector with escape sequence"
+    ],
 
     //attributes
     [

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -67,7 +67,7 @@ export type TraversalType =
     | "parent"
     | "sibling";
 
-const reName = /^(?:\\.|[\w\-\u00b0-\uFFFF])+/,
+const reName = /^(?:\\([\da-f]{1,6}\s?|(\s)|.)|[\w\-\u00b0-\uFFFF])+/,
     reEscape = /\\([\da-f]{1,6}\s?|(\s)|.)/gi,
     //modified version of https://github.com/jquery/sizzle/blob/master/src/sizzle.js#L87
     reAttr = /^\s*((?:\\.|[\w\u00b0-\uFFFF-])+)\s*(?:(\S?)=\s*(?:(['"])([^]*?)\3|(#?(?:\\.|[\w\u00b0-\uFFFF-])*)|)|)\s*(i)?\]/;


### PR DESCRIPTION
Selector validity is tested in https://github.com/jsdom/jsdom/blob/2d51af302581a57ee5b9b65595f1714d669b7ea2/test/web-platform-tests/to-upstream/dom/nodes/ParentNode-querySelector-escapes.html#L88

To verify 

1. goto https://o9vrw.csb.app/
2. Enter "#\26 B"
3. DOM will list a HTMLDivElement while css-select will display null

Code available in https://codesandbox.io/s/css-select-vs-elementqueryselector-o9vrw