### PR TITLE
support deno

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 a CSS selector parser
 
-## Example
+## Node Example
 
 ```js
 const CSSwhat = require("css-what")
@@ -22,6 +22,14 @@ CSSwhat.parse("foo[bar]:baz")
     ]
 ]
 ```
+## Deno Example
+
+```js
+import { parse } from 'https://raw.githubusercontent.com/fb55/css-what/master/src/index.ts';
+
+parse("foo[bar]:baz");
+```
+
 
 ## API
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,7 @@
-export * from "./parse";
-export { default as parse } from "./parse";
-export { default as stringify } from "./stringify";
+// @ts-ignore
+export * from "./parse.ts";
+// @ts-ignore
+export { default as parse } from "./parse.ts";
+// @ts-ignore
+export { default as stringify } from "./stringify.ts";
+

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -1,4 +1,5 @@
-import { Selector } from "./parse";
+// @ts-ignore
+import { Selector } from "./parse.ts";
 
 const actionTypes: { [key: string]: string } = {
     equals: "",


### PR DESCRIPTION
First of all, thank you for this great library.
In this PR i'm adding the support for [deno](https://github.com/denoland/deno).

The reason for `@ts-ignore`'ing the imports is that `tsc` doesn't like file extensions but `deno` requires them.
