### PR TITLE
Use Object.keys as Object.values is not supported in node<7

### DIFF
--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -11,7 +11,9 @@ const actionTypes: { [key: string]: string } = {
 };
 
 const charsToEscape = new Set([
-    ...Object.values(actionTypes).filter(Boolean),
+    ...Object.keys(actionTypes)
+        .map((typeKey) => actionTypes[typeKey])
+        .filter(Boolean),
     ":",
     "[",
     "]",


### PR DESCRIPTION
Object.values was introduced in 138b1019f1fb2d58c0ee8a1f8f92c31573f36953 and it is not supported in node.js until version 7, so it's a mismatch with what's declared in the `engines` section of package.json (node >= 6).

This fixes https://github.com/fb55/css-what/issues/294