### PR TITLE
feat: Add ES6 module export

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     },
     "main": "lib/commonjs/index.js",
     "module": "lib/es/index.js",
-    "types": "lib/index.d.ts",
+    "types": "lib/es/index.d.ts",
     "sideEffects": false,
     "files": [
         "lib/**/*"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
         "url": "https://github.com/sponsors/fb55"
     },
     "repository": {
+        "type": "git",
         "url": "https://github.com/fb55/css-what"
     },
     "main": "lib/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,10 @@
     "repository": {
         "url": "https://github.com/fb55/css-what"
     },
-    "main": "lib/index.js",
+    "main": "lib/commonjs/index.js",
+    "module": "lib/es/index.js",
     "types": "lib/index.d.ts",
+    "sideEffects": false,
     "files": [
         "lib/**/*"
     ],
@@ -24,7 +26,7 @@
         "format:es": "npm run lint:es -- --fix",
         "format:prettier": "npm run prettier -- --write",
         "prettier": "prettier '**/*.{ts,md,json,yml}'",
-        "build": "tsc",
+        "build": "tsc && tsc -p tsconfig.es.json",
         "prepare": "npm run build"
     },
     "devDependencies": {
@@ -45,7 +47,10 @@
     },
     "license": "BSD-2-Clause",
     "jest": {
-        "preset": "ts-jest"
+        "preset": "ts-jest",
+        "roots": [
+            "src"
+        ]
     },
     "prettier": {
         "tabWidth": 4

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export * from "./parse";
-export { default as parse } from "./parse";
-export { default as stringify } from "./stringify";
+export * from "./types";
+export { isTraversal, parse } from "./parse";
+export { stringify } from "./stringify";

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,83 +1,12 @@
-export interface Options {
-    /**
-     * When false, tag names will not be lowercased.
-     * @default true
-     */
-    lowerCaseAttributeNames?: boolean;
-    /**
-     * When false, attribute names will not be lowercased.
-     * @default true
-     */
-    lowerCaseTags?: boolean;
-    /**
-     * When `true`, `xmlMode` implies both `lowerCaseTags` and `lowerCaseAttributeNames` are set to `false`.
-     * Also, `ignoreCase` on attributes will not be inferred based on HTML rules anymore.
-     * @default false
-     */
-    xmlMode?: boolean;
-}
-
-export type Selector =
-    | PseudoSelector
-    | PseudoElement
-    | AttributeSelector
-    | TagSelector
-    | UniversalSelector
-    | Traversal;
-
-export interface AttributeSelector {
-    type: "attribute";
-    name: string;
-    action: AttributeAction;
-    value: string;
-    ignoreCase: boolean | null;
-    namespace: string | null;
-}
-
-type DataType = Selector[][] | null | string;
-
-export interface PseudoSelector {
-    type: "pseudo";
-    name: string;
-    data: DataType;
-}
-
-export interface PseudoElement {
-    type: "pseudo-element";
-    name: string;
-}
-
-export interface TagSelector {
-    type: "tag";
-    name: string;
-    namespace: string | null;
-}
-
-export interface UniversalSelector {
-    type: "universal";
-    namespace: string | null;
-}
-
-export interface Traversal {
-    type: TraversalType;
-}
-
-export type AttributeAction =
-    | "any"
-    | "element"
-    | "end"
-    | "equals"
-    | "exists"
-    | "hyphen"
-    | "not"
-    | "start";
-
-export type TraversalType =
-    | "adjacent"
-    | "child"
-    | "descendant"
-    | "parent"
-    | "sibling";
+import {
+    Options,
+    Selector,
+    AttributeSelector,
+    Traversal,
+    AttributeAction,
+    TraversalType,
+    DataType,
+} from "./types";
 
 const reName = /^[^\\#]?(?:\\(?:[\da-f]{1,6}\s?|.)|[\w\-\u00b0-\uFFFF])+/;
 const reEscape = /\\([\da-f]{1,6}\s?|(\s)|.)/gi;
@@ -220,10 +149,7 @@ function isWhitespace(c: string) {
  * The first dimension represents selectors separated by commas (eg. `sub1, sub2`),
  * the second contains the relevant tokens for that selector.
  */
-export default function parse(
-    selector: string,
-    options?: Options
-): Selector[][] {
+export function parse(selector: string, options?: Options): Selector[][] {
     const subselects: Selector[][] = [];
 
     const endIndex = parseSelector(subselects, `${selector}`, options, 0);

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,4 +1,4 @@
-import {
+import type {
     Options,
     Selector,
     AttributeSelector,

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -1,4 +1,4 @@
-import { Selector } from "./parse";
+import { Selector } from "./types";
 
 const actionTypes: Record<string, string> = {
     equals: "",
@@ -29,7 +29,7 @@ const charsToEscape = new Set([
  *
  * @param selector Selector to stringify.
  */
-export default function stringify(selector: Selector[][]): string {
+export function stringify(selector: Selector[][]): string {
     return selector.map(stringifySubselector).join(", ");
 }
 

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -1,4 +1,4 @@
-import { Selector } from "./types";
+import type { Selector } from "./types";
 
 const actionTypes: Record<string, string> = {
     equals: "",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,80 @@
+export interface Options {
+    /**
+     * When false, tag names will not be lowercased.
+     * @default true
+     */
+    lowerCaseAttributeNames?: boolean;
+    /**
+     * When false, attribute names will not be lowercased.
+     * @default true
+     */
+    lowerCaseTags?: boolean;
+    /**
+     * When `true`, `xmlMode` implies both `lowerCaseTags` and `lowerCaseAttributeNames` are set to `false`.
+     * Also, `ignoreCase` on attributes will not be inferred based on HTML rules anymore.
+     * @default false
+     */
+    xmlMode?: boolean;
+}
+
+export type Selector =
+    | PseudoSelector
+    | PseudoElement
+    | AttributeSelector
+    | TagSelector
+    | UniversalSelector
+    | Traversal;
+
+export interface AttributeSelector {
+    type: "attribute";
+    name: string;
+    action: AttributeAction;
+    value: string;
+    ignoreCase: boolean | null;
+    namespace: string | null;
+}
+
+export type DataType = Selector[][] | null | string;
+
+export interface PseudoSelector {
+    type: "pseudo";
+    name: string;
+    data: DataType;
+}
+
+export interface PseudoElement {
+    type: "pseudo-element";
+    name: string;
+}
+
+export interface TagSelector {
+    type: "tag";
+    name: string;
+    namespace: string | null;
+}
+
+export interface UniversalSelector {
+    type: "universal";
+    namespace: string | null;
+}
+
+export interface Traversal {
+    type: TraversalType;
+}
+
+export type AttributeAction =
+    | "any"
+    | "element"
+    | "end"
+    | "equals"
+    | "exists"
+    | "hyphen"
+    | "not"
+    | "start";
+
+export type TraversalType =
+    | "adjacent"
+    | "child"
+    | "descendant"
+    | "parent"
+    | "sibling";

--- a/tsconfig.es.json
+++ b/tsconfig.es.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "target": "ES2019",
+        "module": "es2015",
+        "outDir": "lib/es",
+        "moduleResolution": "node"
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
         "declaration": true /* Generates corresponding '.d.ts' file. */,
         "declarationMap": true /* Generates a sourcemap for each corresponding '.d.ts' file. */,
         // "sourceMap": true,                     /* Generates corresponding '.map' file. */
-        "outDir": "lib" /* Redirect output structure to the directory. */,
+        "outDir": "lib/commonjs" /* Redirect output structure to the directory. */,
         // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
 
         /* Strict Type-Checking Options */


### PR DESCRIPTION
This PR adds es2015 module support for exports it also compiles those modules in ES2019 syntax format.

I moved the types to a separate file since that made it easier to import them all and re-export them I changed the index so that it's more explicit what functions are being exported.

Had to add roots to jest because it was trying to run the es6 modules though node and that was breaking not sure why not that familiar with jest.

I also added `sideEffects: false` to the package.json since this module doesn't have any sideeffects from importing a module that I can see so that should reduce the bundle size if you only use the parser for example.