### PR TITLE
feat: Support pseudo elements with data

### DIFF
--- a/src/__fixtures__/tests.ts
+++ b/src/__fixtures__/tests.ts
@@ -411,6 +411,33 @@ export const tests: [
                 {
                     type: SelectorType.PseudoElement,
                     name: "foo",
+                    data: null,
+                },
+            ],
+        ],
+        "pseudo-element",
+    ],
+    [
+        "::foo()",
+        [
+            [
+                {
+                    type: SelectorType.PseudoElement,
+                    name: "foo",
+                    data: "",
+                },
+            ],
+        ],
+        "pseudo-element",
+    ],
+    [
+        "::foo(bar())",
+        [
+            [
+                {
+                    type: SelectorType.PseudoElement,
+                    name: "foo",
+                    data: "bar()",
                 },
             ],
         ],
@@ -485,7 +512,7 @@ export const tests: [
                 {
                     type: SelectorType.Pseudo,
                     name: "contains",
-                    data: "(a((foo\\))))",
+                    data: "(a((foo))))",
                 },
             ],
         ],

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -69,20 +69,25 @@ function stringifyToken(
             return getNamespacedName(token);
 
         case SelectorType.PseudoElement:
-            return `::${escapeName(token.name, charsToEscapeInName)}`;
+            return `::${escapeName(token.name, charsToEscapeInName)}${
+                token.data === null
+                    ? ""
+                    : `(${escapeName(token.data, charsToEscapeInPseudoValue)})`
+            }`;
 
         case SelectorType.Pseudo:
-            if (token.data === null)
-                return `:${escapeName(token.name, charsToEscapeInName)}`;
-            if (typeof token.data === "string") {
-                return `:${escapeName(
-                    token.name,
-                    charsToEscapeInName
-                )}(${escapeName(token.data, charsToEscapeInPseudoValue)})`;
-            }
-            return `:${escapeName(token.name, charsToEscapeInName)}(${stringify(
-                token.data
-            )})`;
+            return `:${escapeName(token.name, charsToEscapeInName)}${
+                token.data === null
+                    ? ""
+                    : `(${
+                          typeof token.data === "string"
+                              ? escapeName(
+                                    token.data,
+                                    charsToEscapeInPseudoValue
+                                )
+                              : stringify(token.data)
+                      })`
+            }`;
 
         case SelectorType.Attribute: {
             if (

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,7 @@ export interface PseudoSelector {
 export interface PseudoElement {
     type: SelectorType.PseudoElement;
     name: string;
+    data: string | null;
 }
 
 export interface TagSelector {


### PR DESCRIPTION
Fixes #761

Also now unescapes values within parenthesis, for both pseudo-elements and pseudo-classes.