### PR TITLE
fix: align CSS escape consumption with the spec

### DIFF
--- a/src/__fixtures__/tests.ts
+++ b/src/__fixtures__/tests.ts
@@ -519,6 +519,58 @@ export const tests: [
         ],
         "out-of-range escape replaced with U+FFFD",
     ],
+    [
+        String.raw`\d800 x`,
+        [
+            [
+                {
+                    type: SelectorType.Tag,
+                    namespace: null,
+                    name: "\uFFFDx",
+                },
+            ],
+        ],
+        "surrogate escape replaced with U+FFFD",
+    ],
+    [
+        String.raw`\4A x`,
+        [
+            [
+                {
+                    type: SelectorType.Tag,
+                    namespace: null,
+                    name: "Jx",
+                },
+            ],
+        ],
+        "uppercase hex escape",
+    ],
+    [
+        "\\41\r\nb",
+        [
+            [
+                {
+                    type: SelectorType.Tag,
+                    namespace: null,
+                    name: "Ab",
+                },
+            ],
+        ],
+        "CRLF consumed after hex escape",
+    ],
+    [
+        "ab\\",
+        [
+            [
+                {
+                    type: SelectorType.Tag,
+                    namespace: null,
+                    name: "ab\uFFFD",
+                },
+            ],
+        ],
+        "trailing backslash at EOF replaced with U+FFFD",
+    ],
 
     // Pseudo elements
     [

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -8,8 +8,9 @@ import {
     type TraversalType,
 } from "./types.js";
 
-const reName = /^[^#\\]?(?:\\(?:[\da-f]{1,6}\s?|.)|[\w\u00B0-\uFFFF-])+/;
-const reEscape = /\\([\da-f]{1,6}\s?|(\s)|.)/gi;
+const reName =
+    /^[^#\\]?(?:\\(?:[\da-f]{1,6}(?:\r\n|\s)?|.|$)|[\w\u00B0-\uFFFF-])+/i;
+const reEscape = /\\([\da-f]{1,6}(?:\r\n|\s)?|(\s)|.|$)/gi;
 
 const enum CharCode {
     LeftParenthesis = 40,
@@ -107,6 +108,11 @@ export function isTraversal(selector: Selector): selector is Traversal {
 const stripQuotesFromPseudos = new Set(["contains", "icontains"]);
 
 function funescape(_: string, escaped: string, escapedWhitespace?: string) {
+    // A backslash at EOF (an empty escape) is a parse error → U+FFFD.
+    if (escaped === "") {
+        return "\uFFFD";
+    }
+
     const codePoint = Number.parseInt(escaped, 16);
 
     // NaN means non-codepoint (e.g., \X where X is not hex)
@@ -114,8 +120,12 @@ function funescape(_: string, escaped: string, escapedWhitespace?: string) {
         return escaped;
     }
 
-    // Per CSS spec: U+0000 and out-of-range values → U+FFFD
-    if (codePoint === 0 || codePoint > 0x10_ff_ff) {
+    // Per CSS spec: U+0000, surrogates and out-of-range values → U+FFFD
+    if (
+        codePoint === 0 ||
+        (codePoint >= 0xd8_00 && codePoint <= 0xdf_ff) ||
+        codePoint > 0x10_ff_ff
+    ) {
         return "\uFFFD";
     }
 


### PR DESCRIPTION
## Summary

`funescape` and the identifier tokenizer (`reName`/`reEscape`) diverged from [CSS Syntax Level 3 — "consume an escaped code point"](https://www.w3.org/TR/css-syntax-3/#consume-escaped-code-point) in four ways. Each is fixed here, with regression tests.

### 1. Uppercase hex digits in identifiers

`reName` lacked the `i` flag, so a hex escape with uppercase letters was under-consumed. For example `#hel\6C o`:

- `\6C` only matched `\6` (since `C` isn't in `[\da-f]` without `i`), leaving `C` as a name char and the trailing space as a descendant combinator → parsed as id `hell` + descendant `o`.
- With `i`, `\6C` is consumed as a two-digit hex escape and the following space is consumed as the escape's trailing whitespace → id `hello`, as intended.

`reEscape` already had the `i` flag, so this only needed to be mirrored on `reName`.

### 2. CRLF after a hex escape

The spec consumes a single whitespace after a hex escape, and treats a `CRLF` pair as one whitespace. `\s?` consumed only one of the two characters, leaving a stray `\r`/`\n` in the identifier. Replaced with `(?:\r\n|\s)?` in both regexes.

### 3. Trailing backslash at EOF

A backslash at EOF is a parse error that yields U+FFFD per spec. Previously it was dropped (or threw, depending on the call path). Added a `|$` alternative to both regexes and an `escaped === ""` guard in `funescape`.

### 4. Surrogate code points → U+FFFD

The spec maps U+0000, surrogates, and out-of-range values to U+FFFD. The existing check handled U+0000 and `> 0x10FFFF`, but `String.fromCodePoint` accepts surrogate values and returns lone surrogates, so escapes like `\D800` leaked through. Added the surrogate range to the check.

## Tests

Added fixtures in `src/__fixtures__/tests.ts` covering each case (uppercase hex, CRLF consumption, trailing-backslash → U+FFFD, surrogate → U+FFFD). All existing tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test cases for CSS selector parsing edge cases, including escape sequence handling and end-of-input behavior.

* **Bug Fixes**
  * Enhanced CSS identifier parsing to properly handle invalid escape sequences, surrogate characters, and incomplete escapes at end-of-input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->